### PR TITLE
24.03.2021

### DIFF
--- a/dnd-plugin.tcl
+++ b/dnd-plugin.tcl
@@ -92,9 +92,10 @@ proc ::dnd_object_create::dropped_object_files {mytoplevel files} {
                 }
 	    }
         if { 0 == $found } {
-            set obj [file rootname $file]
-            ::pdwindow::debug "dropping $obj on $::focused_window\n"
-            ::dnd_object_create::make_object $mytoplevel $obj
+			if { [ regexp {^(?:[0-9]+|[a-zA-Z]+)$} $file ] } {set patchname_bsl \\$file} else {set patchname_bsl [regsub -all {\s+} $file "\\\ "]}
+            set dropobj [file rootname $patchname_bsl]
+            ::pdwindow::debug "dropping $dropobj on $::focused_window\n"
+            ::dnd_object_create::make_object $mytoplevel $dropobj
  
 			}
 			

--- a/dnd-plugin.tcl
+++ b/dnd-plugin.tcl
@@ -53,8 +53,8 @@ proc ::dnd_object_create::open_dropped_files {files} {
    }
 }
 
-#---------------------------- 2021 Modification ----------------------------#
-
+# ---------------------------- 2021 Modification ---------------------------- #
+# convert string to ascii values
 proc ::dnd_object_create::string_to_ascii {string_value} {
     set map {}
     set result [lrepeat [string length $string_value] DUMMY]
@@ -70,7 +70,13 @@ proc ::dnd_object_create::string_to_ascii {string_value} {
     return $result
 }
 
-#----------------------------End 2021 Modification --------------------------#
+# prepend white spaces with a backslash
+proc ::dnd_object_create::correct_spaces {string_value} {
+    if {[ regexp {^(?:[0-9]+|[a-zA-Z]+)$} $string_value ]} {set result \\$string_value} else {set result [regsub -all {\s+} $string_value "\\\ "]}
+    return $result
+}
+
+# ----------------------------End 2021 Modification ------------------------- #
 
 proc ::dnd_object_create::dropped_object_files {mytoplevel files} {
     foreach file $files {
@@ -92,7 +98,7 @@ proc ::dnd_object_create::dropped_object_files {mytoplevel files} {
                 }
 	    }
         if { 0 == $found } {
-			if { [ regexp {^(?:[0-9]+|[a-zA-Z]+)$} $file ] } {set patchname_bsl \\$file} else {set patchname_bsl [regsub -all {\s+} $file "\\\ "]}
+			set patchname_bsl [::dnd_object_create::correct_spaces $file]
             set dropobj [file rootname $patchname_bsl]
             ::pdwindow::debug "dropping $dropobj on $::focused_window\n"
             ::dnd_object_create::make_object $mytoplevel $dropobj
@@ -154,9 +160,9 @@ proc ::dnd_object_create::send_filename {w file ext dir obj} {
 
 	#---------------------------- 2021 Modification ----------------------------#
 	# if variable contains only digits: prepend \\, else it's a symbol and all spaces are replaced by "\\\ "
-	if { [ regexp {^(?:[0-9]+|[a-zA-Z]+)$} $obj ] } {set name_bsl \\$obj} else {set name_bsl [regsub -all {\s+} $obj "\\\ "]}
-	if { [ regexp {^(?:[0-9]+|[a-zA-Z]+)$} $dir ] } {set path_bsl \\$dir} else {set path_bsl [regsub -all {\s+} $dir "\\\ "]}
-	if { [ regexp {^(?:[0-9]+|[a-zA-Z]+)$} $file ] } {set fullname_bsl \\$file} else {set fullname_bsl [regsub -all {\s+} $file "\\\ "]}
+	# if { [ regexp {^(?:[0-9]+|[a-zA-Z]+)$} $obj ] } {set name_bsl \\$obj} else {set name_bsl [regsub -all {\s+} $obj "\\\ "]}
+	# if { [ regexp {^(?:[0-9]+|[a-zA-Z]+)$} $dir ] } {set path_bsl \\$dir} else {set path_bsl [regsub -all {\s+} $dir "\\\ "]}
+	# if { [ regexp {^(?:[0-9]+|[a-zA-Z]+)$} $file ] } {set fullname_bsl \\$file} else {set fullname_bsl [regsub -all {\s+} $file "\\\ "]}
 	# special case here since $ext starts with a dot, so we have to change the regexp
 	if { [ regexp {^.(?:[0-9]+|[a-zA-Z]+)$} $ext ] } {set ext_bsl \\$ext} else {set ext_bsl [regsub -all {\s+} $ext "\\\ "]}
 	if { $ext == ""} { set ext_bsl "NULL" }
@@ -165,7 +171,11 @@ proc ::dnd_object_create::send_filename {w file ext dir obj} {
 	set ascii_path [::dnd_object_create::string_to_ascii $dir]
 	set ascii_fullname [::dnd_object_create::string_to_ascii $file]
 	set ascii_ext [::dnd_object_create::string_to_ascii $ext]
-
+	
+	set name_bsl [::dnd_object_create::correct_spaces $obj]
+	set path_bsl [::dnd_object_create::correct_spaces $dir]
+	set fullname_bsl [::dnd_object_create::correct_spaces $file]
+	
 	::pd_connect::pdsend "dnd-dropped -ext symbol $ext_bsl, -name symbol $name_bsl, -path symbol $path_bsl, -fullname symbol $fullname_bsl, -window-name symbol $::focused_window, -global-coords list $x $y, -ascii-ext list $ascii_ext, -ascii-name list $ascii_name, -ascii-path list $ascii_path, -ascii-fullname list $ascii_fullname, -drop list $posx $posy $fullname_bsl"	
 	
 	#-------------------------- End of 2021 Modification -----------------------#


### PR DESCRIPTION
hi,
found a bug in the section, where a .pd file can be dropped onto a patch canvas (and is then treated like a pd object box).
we need to escape spaces in the filename here with a literal backslash, else the object can't be created.

i fixed that in my last commit. please check with a filename like "00 34 55.pd" dropped onto an empty pd canvas